### PR TITLE
:bug: Fail when $_SERVER['SERVER_ADDR'] is not presented

### DIFF
--- a/src/Process/ProcessIpTag.php
+++ b/src/Process/ProcessIpTag.php
@@ -7,8 +7,10 @@ use Jaeger\Tag\StringTag;
 
 class ProcessIpTag extends StringTag
 {
+    private const IP_DEFAULT = '127.0.0.1';
+    
     public function __construct()
     {
-        parent::__construct('ip', $_SERVER['SERVER_ADDR']);
+        parent::__construct('ip', $_SERVER['SERVER_ADDR'] ?? self::IP_DEFAULT);
     }
 }


### PR DESCRIPTION
For php built-in server `SERVER_ADDR` is not presented. After that, constructor fails.

So, I think we can put default localhost IP address instead.