### PR TITLE
Resolve symfony 5.4+ / PHP 8.1+ deprecations

### DIFF
--- a/src/Codec/CodecRegistry.php
+++ b/src/Codec/CodecRegistry.php
@@ -7,11 +7,19 @@ class CodecRegistry implements \ArrayAccess
 {
     private $codecs = [];
 
+    /**
+     * @return bool
+     */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->codecs);
     }
 
+    /**
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (false === array_key_exists($offset, $this->codecs)) {
@@ -21,6 +29,10 @@ class CodecRegistry implements \ArrayAccess
         return $this->codecs[$offset];
     }
 
+    /**
+     * @return $this
+     */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->codecs[$offset] = $value;
@@ -28,6 +40,10 @@ class CodecRegistry implements \ArrayAccess
         return $this;
     }
 
+    /**
+     * @return $this
+     */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         if (false === array_key_exists($offset, $this->codecs)) {

--- a/src/Span/Context/SpanContext.php
+++ b/src/Span/Context/SpanContext.php
@@ -64,6 +64,10 @@ class SpanContext implements \IteratorAggregate
         return $this->baggage;
     }
 
+    /**
+     * @return \Traversable
+     */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->baggage);


### PR DESCRIPTION
Prepare for PHP 8.1 deprecations - add return types in phpdoc and #[\ReturnTypeWillChange]

Also Symfony deprecation messages:
>   1x: Method "IteratorAggregate::getIterator()" might add "\Traversable" as a native return type declaration in the future. Do the same in implementation "Jaeger\Span\Context\SpanContext" now to avoid errors or add an explicit @return annotation to suppress this message.

See also: https://wiki.php.net/rfc/internal_method_return_types