### PR TITLE
Add support for 128 bit trace ids

### DIFF
--- a/src/Codec/TextCodec.php
+++ b/src/Codec/TextCodec.php
@@ -18,7 +18,7 @@ class TextCodec implements CodecInterface
         }
 
         return new SpanContext(
-            $this->convertInt64($elements[0]),
+            $elements[0],
             $this->convertInt64($elements[1]),
             $this->convertInt64($elements[2]),
             $this->convertInt64($elements[3])
@@ -35,7 +35,7 @@ class TextCodec implements CodecInterface
     public function encode(SpanContext $context)
     {
         return sprintf(
-            '%x:%x:%x:%x',
+            '%s:%x:%x:%x',
             $context->getTraceId(),
             $context->getSpanId(),
             $context->getParentId(),

--- a/src/Span/Context/SpanContext.php
+++ b/src/Span/Context/SpanContext.php
@@ -16,7 +16,7 @@ class SpanContext implements \IteratorAggregate
     private $baggage;
 
     public function __construct(
-        int $traceId,
+        string $traceId,
         int $spanId,
         int $parentId,
         int $flags = 0,
@@ -29,7 +29,7 @@ class SpanContext implements \IteratorAggregate
         $this->baggage = $baggage;
     }
 
-    public function getTraceId(): int
+    public function getTraceId(): string
     {
         return $this->traceId;
     }

--- a/src/Span/Factory/SpanFactory.php
+++ b/src/Span/Factory/SpanFactory.php
@@ -36,7 +36,7 @@ class SpanFactory implements SpanFactoryInterface
         return new Span(
             $tracer,
             new SpanContext(
-                (int)$traceId,
+                sprintf('%x', $traceId),
                 (int)$spanId,
                 0,
                 (int)$samplerResult->getFlags()


### PR DESCRIPTION
Hi Taras,

Thank you for the all the hard work that went into this. We've been very very happy users of your lib for a few years now.

We found that **128 bit trace ids are not supported yet**. This is both because of the way the headers are parsed, and also because the trace id is stored as an `int`, which is platform dependent for PHP and would usually only be 64 bits wide.

In our case, the Itsio gateway injects 128 bit trace ids by default, and we didn't know why tracing was not working for us.

According to the B3 spec, trace ids can be 64 or 128 bit long, while span ids can only be 64 bit long.

With this change, the trace id will no longer be parsed, it will be kept as a string as is. It will be parsed when it's encoded and be split in `traceIdHigh` and `traceIdLow`.

I've tested this code locally, and it seems to work both for 128 and 64 trace ids. It also works when getting the trancing context from headers, and also when generating a tracing context directly.

Breaking changes:
- Return type of Jaeger\Span\Context\SpanContext::getTraceId() has been
changed from int to string