### PR TITLE
Allow installing `apache/thrift` up to 0.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "require": {
     "php": ">=7.4",
     "ext-sockets": "*",
-    "apache/thrift": ">=0.11, <0.16"
+    "apache/thrift": ">=0.11, <0.17"
   },
   "require-dev": {
     "phpunit/phpunit": "@stable"


### PR DESCRIPTION
There are no BC breaking changes in 0.16
https://github.com/apache/thrift/blob/v0.16.0/CHANGES.md