### PR TITLE
:package: Resolve PHP deprecation

### DIFF
--- a/src/Tag/AbstractTag.php
+++ b/src/Tag/AbstractTag.php
@@ -10,11 +10,11 @@ abstract class AbstractTag extends Tag implements TagInterface
     public function __construct(
         string $key,
         int $type,
-        string $vStr = null,
-        float $vDouble = null,
-        bool $vBool = null,
-        int $vLong = null,
-        string $vBinary = null
+        ?string $vStr = null,
+        ?float $vDouble = null,
+        ?bool $vBool = null,
+        ?int $vLong = null,
+        ?string $vBinary = null
     ) {
         $this->key = $key;
         $this->vType = $type;


### PR DESCRIPTION
> "Deprecated: Jaeger\Tag\AbstractTag::__construct(): Implicitly marking parameter $vStr as nullable is deprecated, the explicit nullable type must be used instead